### PR TITLE
Fixed scaffolding damage and handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     modImplementation include("eu.pb4:polymer-virtual-entity:${polymer_version}")
     modImplementation include("eu.pb4:polymer-networking:${polymer_version}")
 
+    // Mixin extras
+    include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.5.0-rc.2")))
+
     modRuntimeOnly "eu.pb4:polymer-autohost:${polymer_version}"
 }
 

--- a/src/main/java/dev/michaud/pandas_blueprints/mixin/MixinFallLocation.java
+++ b/src/main/java/dev/michaud/pandas_blueprints/mixin/MixinFallLocation.java
@@ -1,0 +1,29 @@
+package dev.michaud.pandas_blueprints.mixin;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.michaud.pandas_blueprints.tags.ModTags;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.damage.FallLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Makes it so that our custom scaffolding is treated as scaffolding in death messages.
+ */
+@Mixin(FallLocation.class)
+public abstract class MixinFallLocation {
+
+  @Definition(id = "state", local = @Local(type = BlockState.class, argsOnly = true))
+  @Definition(id = "isOf", method = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z")
+  @Definition(id = "SCAFFOLDING", field = "Lnet/minecraft/block/Blocks;SCAFFOLDING:Lnet/minecraft/block/Block;")
+  @Expression("state.isOf(SCAFFOLDING)")
+  @ModifyExpressionValue(method = "fromBlockState", at = @At("MIXINEXTRAS:EXPRESSION"))
+  private static boolean isStateScaffolding(boolean original,
+      @Local(argsOnly = true) BlockState state) {
+    return original || state.isIn(ModTags.SCAFFOLDING_BLOCK);
+  }
+
+}

--- a/src/main/java/dev/michaud/pandas_blueprints/mixin/MixinLivingEntity.java
+++ b/src/main/java/dev/michaud/pandas_blueprints/mixin/MixinLivingEntity.java
@@ -1,0 +1,35 @@
+package dev.michaud.pandas_blueprints.mixin;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import dev.michaud.pandas_blueprints.tags.ModTags;
+import net.minecraft.entity.Attackable;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.world.World;
+import net.minecraft.world.waypoint.ServerWaypoint;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Makes it so that our custom scaffolding is treated as a climbable block just like real boy
+ * scaffolding.
+ */
+@Mixin(LivingEntity.class)
+public abstract class MixinLivingEntity extends Entity implements Attackable, ServerWaypoint {
+
+  public MixinLivingEntity(EntityType<?> type, World world) {
+    super(type, world);
+  }
+
+  @Definition(id = "isOf", method = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z")
+  @Definition(id = "SCAFFOLDING", field = "Lnet/minecraft/block/Blocks;SCAFFOLDING:Lnet/minecraft/block/Block;")
+  @Definition(id = "getBlockStateAtPos", method = "Lnet/minecraft/entity/LivingEntity;getBlockStateAtPos()Lnet/minecraft/block/BlockState;")
+  @Expression("this.getBlockStateAtPos().isOf(SCAFFOLDING)")
+  @ModifyExpressionValue(method = "applyClimbingSpeed", at = @At("MIXINEXTRAS:EXPRESSION"))
+  private boolean getIsBlockStateAtPosScaffolding(boolean original) {
+    return original || getBlockStateAtPos().isIn(ModTags.SCAFFOLDING_BLOCK);
+  }
+}

--- a/src/main/resources/data/minecraft/tags/block/climbable.json
+++ b/src/main/resources/data/minecraft/tags/block/climbable.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#greenpanda:scaffolding"
+  ]
+}

--- a/src/main/resources/pandas_blueprints.mixins.json
+++ b/src/main/resources/pandas_blueprints.mixins.json
@@ -6,7 +6,9 @@
   "mixins": [
     "MixinArmorStandEntity",
     "MixinAxeItem",
+    "MixinFallLocation",
     "MixinHoneycombItem",
+    "MixinLivingEntity",
     "MixinScaffoldingBlock",
     "MixinScaffoldingItem"
   ],
@@ -14,5 +16,8 @@
   ],
   "injectors": {
     "defaultRequire": 1
+  },
+  "mixinextras": {
+    "minVersion": "0.5.0-rc.2"
   }
 }


### PR DESCRIPTION
* Copper scaffolding is now properly treated as a climbable clock 
* You don't take damage when descending copper scaffolding 
* If you actually fall off of the scaffolding the death message will now read "fell off scaffolding" in cases where it would with normal scaffolding.