### PR TITLE
Fixed scaffolding item bug

### DIFF
--- a/src/main/java/dev/michaud/pandas_blueprints/blocks/ModBlocks.java
+++ b/src/main/java/dev/michaud/pandas_blueprints/blocks/ModBlocks.java
@@ -3,17 +3,15 @@ package dev.michaud.pandas_blueprints.blocks;
 import dev.michaud.pandas_blueprints.PandasBlueprints;
 import dev.michaud.pandas_blueprints.blocks.scaffolding.OxidizableScaffoldingBlock;
 import java.util.function.Function;
-import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.registry.OxidizableBlocksRegistry;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
-import net.minecraft.block.Oxidizable;
 import net.minecraft.block.Oxidizable.OxidationLevel;
 import net.minecraft.block.enums.NoteBlockInstrument;
-import net.minecraft.item.ItemGroups;
-import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.sound.BlockSoundGroup;
@@ -24,7 +22,8 @@ public class ModBlocks {
 
   public static final Block BLUEPRINT_TABLE = register("blueprint_table", BlueprintTableBlock::new,
       AbstractBlock.Settings.create()
-          .mapColor(state -> state.get(BlueprintTableBlock.HAS_BLUEPRINT) ? MapColor.BLUE : MapColor.YELLOW)
+          .mapColor(state -> state.get(BlueprintTableBlock.HAS_BLUEPRINT) ? MapColor.BLUE
+              : MapColor.YELLOW)
           .instrument(NoteBlockInstrument.BASS)
           .strength(2.5F)
           .sounds(BlockSoundGroup.BAMBOO_WOOD)
@@ -53,13 +52,16 @@ public class ModBlocks {
   public static final Block WAXED_COPPER_SCAFFOLDING = register("waxed_copper_scaffolding",
       settings -> new OxidizableScaffoldingBlock(OxidationLevel.UNAFFECTED, settings),
       AbstractBlock.Settings.copy(COPPER_SCAFFOLDING));
-  public static final Block WAXED_EXPOSED_COPPER_SCAFFOLDING = register("waxed_exposed_copper_scaffolding",
+  public static final Block WAXED_EXPOSED_COPPER_SCAFFOLDING = register(
+      "waxed_exposed_copper_scaffolding",
       settings -> new OxidizableScaffoldingBlock(OxidationLevel.EXPOSED, settings),
       AbstractBlock.Settings.copy(EXPOSED_COPPER_SCAFFOLDING));
-  public static final Block WAXED_WEATHERED_COPPER_SCAFFOLDING = register("waxed_weathered_copper_scaffolding",
+  public static final Block WAXED_WEATHERED_COPPER_SCAFFOLDING = register(
+      "waxed_weathered_copper_scaffolding",
       settings -> new OxidizableScaffoldingBlock(OxidationLevel.WEATHERED, settings),
       AbstractBlock.Settings.copy(WEATHERED_COPPER_SCAFFOLDING));
-  public static final Block WAXED_OXIDIZED_COPPER_SCAFFOLDING = register("waxed_oxidized_copper_scaffolding",
+  public static final Block WAXED_OXIDIZED_COPPER_SCAFFOLDING = register(
+      "waxed_oxidized_copper_scaffolding",
       settings -> new OxidizableScaffoldingBlock(OxidationLevel.OXIDIZED, settings),
       AbstractBlock.Settings.copy(OXIDIZED_COPPER_SCAFFOLDING));
 
@@ -67,9 +69,10 @@ public class ModBlocks {
       AbstractBlock.Settings settings) {
 
     final Identifier id = Identifier.of(PandasBlueprints.MOD_ID, name);
-    final RegistryKey<Block> key = RegistryKey.of(RegistryKeys.BLOCK, id);
+    final RegistryKey<Block> registryKey = RegistryKey.of(RegistryKeys.BLOCK, id);
+    final Block block = factory.apply(settings.registryKey(registryKey));
 
-    return Blocks.register(key, factory, settings);
+    return Registry.register(Registries.BLOCK, registryKey, block);
   }
 
   public static void registerModBlocks() {

--- a/src/main/java/dev/michaud/pandas_blueprints/blocks/scaffolding/OxidizableScaffoldingBlock.java
+++ b/src/main/java/dev/michaud/pandas_blueprints/blocks/scaffolding/OxidizableScaffoldingBlock.java
@@ -1,8 +1,6 @@
 package dev.michaud.pandas_blueprints.blocks.scaffolding;
 
-import dev.michaud.pandas_blueprints.PandasBlueprints;
 import dev.michaud.pandas_blueprints.blocks.BlockWithCustomSounds;
-import dev.michaud.pandas_blueprints.tags.ModTags;
 import eu.pb4.polymer.blocks.api.PolymerTexturedBlock;
 import eu.pb4.polymer.core.api.item.PolymerBlockItem;
 import eu.pb4.polymer.resourcepack.api.PolymerResourcePackUtils;
@@ -11,7 +9,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Oxidizable;
 import net.minecraft.block.ScaffoldingBlock;
-import net.minecraft.block.ShapeContext;
 import net.minecraft.block.Waterloggable;
 import net.minecraft.entity.FallingBlockEntity;
 import net.minecraft.item.ItemPlacementContext;
@@ -19,18 +16,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager.Builder;
-import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.IntProperty;
-import net.minecraft.state.property.Properties;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
-import net.minecraft.world.BlockView;
-import net.minecraft.world.WorldView;
-import net.minecraft.world.tick.ScheduledTickView;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.packettweaker.PacketContext;
 
@@ -83,8 +73,14 @@ public class OxidizableScaffoldingBlock extends ScaffoldingBlock implements Poly
   }
 
   @Override
+  public OxidationLevel getDegradationLevel() {
+    return oxidationLevel;
+  }
+
+  @Override
   public BlockState getPolymerBlockState(BlockState state, PacketContext context) {
-    return OxidizableScaffoldingBlockModels.getPolymerBlockState(oxidationLevel, state.get(BOTTOM), state.get(WATERLOGGED));
+    return OxidizableScaffoldingBlockModels.getPolymerBlockState(oxidationLevel, state.get(BOTTOM),
+        state.get(WATERLOGGED));
   }
 
   @Override
@@ -108,30 +104,20 @@ public class OxidizableScaffoldingBlock extends ScaffoldingBlock implements Poly
   }
 
   @Override
-  public OxidationLevel getDegradationLevel() {
-    return oxidationLevel;
-  }
-
-  @Override
   public Set<BlockState> getAllClientBlockStates() {
     return OxidizableScaffoldingBlockModels.ALL_STATES;
   }
 
   public static class OxidizableScaffoldingBlockItem extends PolymerBlockItem {
 
-    final String itemModelName;
-
     public OxidizableScaffoldingBlockItem(Block block, Settings settings) {
       super(block, settings, Items.SCAFFOLDING);
-
-      OxidationLevel level = ((Oxidizable) block).getDegradationLevel();
-      itemModelName = modelFromOxidation(level);
     }
 
     @Override
     public @Nullable Identifier getPolymerItemModel(ItemStack stack, PacketContext context) {
       if (PolymerResourcePackUtils.hasMainPack(context)) {
-        return Identifier.of(PandasBlueprints.GREENPANDA_ID, itemModelName);
+        return OxidizableScaffoldingBlockModels.getPolymerItemModel(getBlock());
       } else {
         return Identifier.ofVanilla("scaffolding");
       }
@@ -146,14 +132,6 @@ public class OxidizableScaffoldingBlock extends ScaffoldingBlock implements Poly
     @Override
     protected boolean checkStatePlacement() {
       return false;
-    }
-
-    private static String modelFromOxidation(OxidationLevel level) {
-      if (level == OxidationLevel.UNAFFECTED) {
-        return "copper_scaffolding";
-      } else {
-        return level.asString() + "_copper_scaffolding";
-      }
     }
   }
 

--- a/src/main/java/dev/michaud/pandas_blueprints/blocks/scaffolding/OxidizableScaffoldingBlockModels.java
+++ b/src/main/java/dev/michaud/pandas_blueprints/blocks/scaffolding/OxidizableScaffoldingBlockModels.java
@@ -1,11 +1,13 @@
 package dev.michaud.pandas_blueprints.blocks.scaffolding;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import dev.michaud.pandas_blueprints.PandasBlueprints;
 import eu.pb4.polymer.blocks.api.BlockModelType;
 import eu.pb4.polymer.blocks.api.PolymerBlockModel;
 import eu.pb4.polymer.blocks.api.PolymerBlockResourceUtils;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Oxidizable.OxidationLevel;
 import net.minecraft.util.Identifier;
@@ -35,10 +37,10 @@ public class OxidizableScaffoldingBlockModels {
   public static final ImmutableSet<BlockState> ALL_STATES;
 
   static {
-    ImmutableMap.Builder<OxidationLevel, BlockState> topBuilder = ImmutableMap.builder();
-    ImmutableMap.Builder<OxidationLevel, BlockState> bottomBuilder = ImmutableMap.builder();
-    ImmutableMap.Builder<OxidationLevel, BlockState> topWaterloggedBuilder = ImmutableMap.builder();
-    ImmutableMap.Builder<OxidationLevel, BlockState> bottomWaterloggedBuilder = ImmutableMap.builder();
+    Builder<OxidationLevel, BlockState> topBuilder = ImmutableMap.builder();
+    Builder<OxidationLevel, BlockState> bottomBuilder = ImmutableMap.builder();
+    Builder<OxidationLevel, BlockState> topWaterloggedBuilder = ImmutableMap.builder();
+    Builder<OxidationLevel, BlockState> bottomWaterloggedBuilder = ImmutableMap.builder();
 
     TOP_MODELS.forEach((level, model) -> {
       topBuilder.put(level, PolymerBlockResourceUtils
@@ -83,6 +85,21 @@ public class OxidizableScaffoldingBlockModels {
     } else {
       return POLYMER_BLOCK_STATES_BOTTOM_WATERLOGGED.get(oxidationLevel);
     }
+  }
+
+  public static Identifier getPolymerItemModel(Block block) {
+    if (!(block instanceof OxidizableScaffoldingBlock scaffoldingBlock)) {
+      throw new IllegalArgumentException("Must be a scaffolding block");
+    }
+
+    final String modelName = switch (scaffoldingBlock.getDegradationLevel()) {
+      case UNAFFECTED -> "copper_scaffolding";
+      case EXPOSED -> "exposed_copper_scaffolding";
+      case WEATHERED -> "weathered_copper_scaffolding";
+      case OXIDIZED -> "oxidized_copper_scaffolding";
+    };
+
+    return Identifier.of(PandasBlueprints.GREENPANDA_ID, modelName);
   }
 
   private static @NotNull PolymerBlockModel pathToBlockModel(String path) {


### PR DESCRIPTION
+Prevented `asItem()` being called before copper scaffolding item was registered (see `MixinScaffoldingBlock`, outline shape)
+Get outline shape now checks if the held item is *any* of the items in `ModTags.SCAFFOLDING_ITEM` (though it's likely uncessesary, since the shape is always consistent on the client).